### PR TITLE
Add per-organization Totem toggles for feature modules

### DIFF
--- a/app/client/src/vue/components/AppMenu.vue
+++ b/app/client/src/vue/components/AppMenu.vue
@@ -21,7 +21,7 @@
                 </div>
             </li>
 
-            <li>
+            <li v-if="authStore.hasTotem('announcements')">
                 <router-link to="/announcements" class="nav_link" :class="{ 'nav_link--active': $route.name === 'Announcements' }" @click="closeAllMenus">
                     <div class="nav_icon">
                         <img
@@ -46,7 +46,7 @@
                 </router-link>
             </li>
 
-            <li>
+            <li v-if="authStore.hasTotem('calendar')">
                 <router-link to="/calendar" class="nav_link" :class="{ 'nav_link--active': $route.name === 'Calendar' }" @click="closeAllMenus">
                     <div class="nav_icon">
                         <img
@@ -73,7 +73,7 @@
         <!-- Secondary Menu -->
         <div class="secondarynav">
             <ul class="secondary_menu">
-                <li>
+                <li v-if="authStore.hasTotem('food')">
                     <router-link to="/food" class="nav_link" :class="{ 'nav_link--active': $route.name === 'Food' }" @click="closeAllMenus">
                         <div class="nav_icon">
                             <img :src="essenTotem" alt="Essen Icon" class="nav_image">
@@ -82,7 +82,7 @@
                     </router-link>
                 </li>
 
-                <li>
+                <li v-if="authStore.hasTotem('links')">
                     <router-link to="/links" class="nav_link" :class="{ 'nav_link--active': $route.name === 'Links' }" @click="closeAllMenus">
                         <div class="nav_icon">
                             <img :src="downloadsTotem" alt="Links Icon" class="nav_image">
@@ -91,7 +91,7 @@
                     </router-link>
                 </li>
 
-                <li>
+                <li v-if="authStore.hasTotem('map')">
                     <router-link to="/map" class="nav_link" :class="{ 'nav_link--active': $route.name === 'Map' }" @click="closeAllMenus">
                         <div class="nav_icon">
                             <img :src="kartenTotem" alt="Karte Icon" class="nav_image">
@@ -100,7 +100,7 @@
                     </router-link>
                 </li>
 
-                <li>
+                <li v-if="authStore.hasTotem('tasks')">
                     <router-link to="/tasks" class="nav_link" :class="{ 'nav_link--active': $route.name === 'Tasks' }" @click="closeAllMenus">
                         <div class="nav_icon">
                             <img :src="todosTotem" alt="Aufgaben Icon" class="nav_image">

--- a/app/client/src/vue/router/index.js
+++ b/app/client/src/vue/router/index.js
@@ -41,31 +41,31 @@ const routes = [
     path: '/calendar',
     name: 'Calendar',
     component: Calendar,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'calendar' }
   },
   {
     path: '/food/meal/:id',
     name: 'MealDetail',
     component: MealDetail,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'food' }
   },
   {
     path: '/food',
     name: 'Food',
     component: Food,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'food' }
   },
   {
     path: '/announcements',
     name: 'Announcements',
     component: Announcements,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'announcements' }
   },
   {
     path: '/announcements/:id',
     name: 'AnnouncementDetail',
     component: AnnouncementDetail,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'announcements' }
   },
   {
     path: '/profile',
@@ -83,31 +83,31 @@ const routes = [
     path: '/map',
     name: 'Map',
     component: Map,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'map' }
   },
   {
     path: '/map/new',
     name: 'MapCreate',
     component: MapCreate,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'map' }
   },
   {
     path: '/map/:mapId/layer/:layerId/edit',
     name: 'MapLayerEdit',
     component: MapLayerEdit,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'map' }
   },
   {
     path: '/map/:id',
     name: 'MapDetail',
     component: MapDetail,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'map' }
   },
   {
     path: '/links',
     name: 'Links',
     component: Links,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'links' }
   },
   {
     path: '/organizations',
@@ -125,13 +125,13 @@ const routes = [
     path: '/tasks',
     name: 'Tasks',
     component: Tasks,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'tasks' }
   },
   {
     path: '/tasks/:hash',
     name: 'TaskDetail',
     component: TaskDetail,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, totem: 'tasks' }
   },
   {
     path: '/login',
@@ -172,7 +172,13 @@ router.beforeEach(async (to, from, next) => {
     next({ name: 'Dashboard' })
     return
   }
-  
+
+  // Redirect away from Totems (feature modules) that are disabled for the user's organization(s)
+  if (to.meta.totem && !authStore.hasTotem(to.meta.totem)) {
+    next({ name: 'Dashboard' })
+    return
+  }
+
   next()
 })
 

--- a/app/client/src/vue/stores/auth.js
+++ b/app/client/src/vue/stores/auth.js
@@ -15,7 +15,15 @@ export const useAuthStore = defineStore('auth', () => {
     if (!user.value) return ''
     return `${user.value.FirstName} ${user.value.Surname}`
   })
-  
+
+  // Whether a given Totem (feature module, e.g. 'calendar', 'food') is enabled
+  // for the current user's organization(s). Defaults to visible when unknown.
+  function hasTotem(totemKey) {
+    const enabledTotems = user.value?.EnabledTotems
+    if (!enabledTotems || !(totemKey in enabledTotems)) return true
+    return !!enabledTotems[totemKey]
+  }
+
   // Actions
   async function checkAuth() {
     try {
@@ -97,6 +105,7 @@ export const useAuthStore = defineStore('auth', () => {
     checkAuth,
     login,
     logout,
-    updateUser
+    updateUser,
+    hasTotem
   }
 })

--- a/app/src/Controllers/Api/AuthApiController.php
+++ b/app/src/Controllers/Api/AuthApiController.php
@@ -114,6 +114,7 @@ class AuthApiController extends ApiController
             'FoodPreference'  => $member->FoodPreference ?: 'None',
             'DateOfBirth'    => $member->DateOfBirth,
             'Joindate'       => $member->Joindate,
+            'EnabledTotems'  => $member->getEnabledTotems(),
         ];
 
         // Add profile image if exists

--- a/app/src/Extensions/MemberExtension.php
+++ b/app/src/Extensions/MemberExtension.php
@@ -260,4 +260,29 @@ class MemberExtension extends Extension
             ])
             ->column('OrganizationID');
     }
+
+    /**
+     * Returns which Totems (feature modules) should be visible to this member,
+     * i.e. enabled in at least one of the organizations they are an active member of.
+     * Members without any organization see every Totem, since no org has restricted anything yet.
+     *
+     * @return array<string, bool>
+     */
+    public function getEnabledTotems(): array
+    {
+        $organizationIDs = $this->owner->getOrganizationIDs();
+
+        if (empty($organizationIDs)) {
+            return array_fill_keys(array_keys(Organization::config()->get('totem_fields')), true);
+        }
+
+        $enabled = [];
+        foreach (Organization::get()->filter('ID', $organizationIDs) as $organization) {
+            foreach ($organization->getEnabledTotems() as $totemKey => $isEnabled) {
+                $enabled[$totemKey] = ($enabled[$totemKey] ?? false) || $isEnabled;
+            }
+        }
+
+        return $enabled;
+    }
 }

--- a/app/src/Teams/Organization.php
+++ b/app/src/Teams/Organization.php
@@ -6,6 +6,8 @@ use App\Teams\OrganizationMembership;
 use SilverStripe\Assets\Image;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\Tab;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 
@@ -16,6 +18,12 @@ use SilverStripe\Security\PermissionProvider;
  * @property ?string $Description
  * @property ?string $JoinMode
  * @property ?string $Username
+ * @property bool $EnableAnnouncements
+ * @property bool $EnableCalendar
+ * @property bool $EnableFood
+ * @property bool $EnableLinks
+ * @property bool $EnableMap
+ * @property bool $EnableTasks
  * @property int $LogoID
  * @property int $CoverImageID
  * @method \SilverStripe\Assets\Image Logo()
@@ -29,11 +37,39 @@ use SilverStripe\Security\PermissionProvider;
  */
 class Organization extends DataObject implements PermissionProvider
 {
+    /**
+     * Maps the frontend Totem key to the DB field that enables it for this organization.
+     */
+    private static $totem_fields = [
+        'announcements' => 'EnableAnnouncements',
+        'calendar'      => 'EnableCalendar',
+        'food'          => 'EnableFood',
+        'links'         => 'EnableLinks',
+        'map'           => 'EnableMap',
+        'tasks'         => 'EnableTasks',
+    ];
+
     private static $db = [
         "Title"       => "Varchar(255)",
         "Description" => "Text",
         "JoinMode"    => "Enum('open,application,invite_only,hidden','invite_only')",
         "Username"    => "Varchar(100)",
+
+        "EnableAnnouncements" => "Boolean(1)",
+        "EnableCalendar"      => "Boolean(1)",
+        "EnableFood"          => "Boolean(1)",
+        "EnableLinks"         => "Boolean(1)",
+        "EnableMap"           => "Boolean(1)",
+        "EnableTasks"         => "Boolean(1)",
+    ];
+
+    private static $defaults = [
+        "EnableAnnouncements" => true,
+        "EnableCalendar"      => true,
+        "EnableFood"          => true,
+        "EnableLinks"         => true,
+        "EnableMap"           => true,
+        "EnableTasks"         => true,
     ];
 
     private static $has_one = [
@@ -65,6 +101,13 @@ class Organization extends DataObject implements PermissionProvider
         "JoinMode"    => "Beitrittsmodus",
         "CoverImage"  => "Coverbild",
         "Memberships" => "Mitgliedschaften",
+
+        "EnableAnnouncements" => "Ankündigungen",
+        "EnableCalendar"      => "Kalender",
+        "EnableFood"          => "Essensplanung",
+        "EnableLinks"         => "Links & Downloads",
+        "EnableMap"           => "Lagepläne",
+        "EnableTasks"         => "Aufgaben",
     ];
 
     private static $table_name = 'Organization';
@@ -89,7 +132,31 @@ class Organization extends DataObject implements PermissionProvider
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
+
+        $fields->addFieldToTab('Root', Tab::create('Totems', 'Totems'));
+        foreach (self::$totem_fields as $fieldName) {
+            $fields->addFieldToTab(
+                'Root.Totems',
+                CheckboxField::create($fieldName, $this->fieldLabel($fieldName))
+            );
+        }
+
         return $fields;
+    }
+
+    /**
+     * Returns which Totems (feature modules) are enabled for this organization,
+     * keyed by the frontend Totem key (e.g. 'calendar', 'food').
+     *
+     * @return array<string, bool>
+     */
+    public function getEnabledTotems(): array
+    {
+        $enabled = [];
+        foreach (self::$totem_fields as $totemKey => $fieldName) {
+            $enabled[$totemKey] = (bool) $this->$fieldName;
+        }
+        return $enabled;
     }
 
     public function providePermissions()


### PR DESCRIPTION
Organizations can now enable/disable individual Totems (Kalender,
Essensplanung, Lagepläne, Aufgaben, Links & Downloads, Ankündigungen)
in the CMS. The frontend only shows nav links and allows routing to
Totems enabled in at least one of the user's organizations.